### PR TITLE
Add initialization for type

### DIFF
--- a/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/functions/JsonFunction.java
+++ b/src/main/java/com/github/alexliesenfeld/querydsl/jpa/hibernate/functions/JsonFunction.java
@@ -28,6 +28,7 @@ public class JsonFunction extends AbstractJsonSQLFunction {
 
   public JsonFunction(Type type, String functionName) {
     this();
+    this.type = type;
     setFunctionName(functionName);
   }
 


### PR DESCRIPTION
function `getReturnType` return `type` but there is no initialization for type.(it cause some error when using it in select clause)
So i add it